### PR TITLE
Add `from_sets` data loader (resolves #23)

### DIFF
--- a/upsetplot/data.py
+++ b/upsetplot/data.py
@@ -1,7 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
-import pandas as pd
+import operator
+from collections import OrderedDict
+
 import numpy as np
+import pandas as pd
 
 
 def generate_data(seed=0, n_samples=10000, n_sets=3, aggregated=False):
@@ -16,3 +19,51 @@ def generate_data(seed=0, n_samples=10000, n_sets=3, aggregated=False):
     if aggregated:
         return df.value.groupby(level=list(range(n_sets))).count()
     return df.value
+
+
+def from_sets(data):
+    """
+    Data loader for a dict of sets
+
+    :param Dict[str, set[str]] data:
+    :return: Multi-Index Series of intersection counts
+    :rtype: pd.Series
+    """
+    # Convert dict into OrderedDict to preserve Key/Value order
+    data = OrderedDict(data)
+
+    # Construct Index
+    tf_array = [[True, False]] * len(data)
+    index = pd.MultiIndex.from_product(tf_array, names=data.keys())
+
+    # Curate values from each intersection group
+    values = []
+    for i in index:
+        values.append(_intersection_counts(data.values(), i))
+
+    return pd.Series(values, index=index)
+
+
+def _intersection_counts(sets, bool_tuple):
+    """
+    Given list of sets and boolean tuple, return count of intersection
+
+    :param List[sets[str]] sets:
+    :param Tuple[bool] bool_tuple:
+    :return: Count of intersection
+    :rtype: int
+    """
+    # For all False case, return 0
+    if True not in bool_tuple:
+        return 0
+
+    # Operator dictionary
+    set_ops = {True: operator.and_, False: operator.sub}
+
+    # For each grouping, perform set operation
+    zipped = sorted(list(zip(bool_tuple, sets)), reverse=True)
+    _, base = zipped[0]
+    for operation, s in zipped[1:]:
+        base = set_ops[operation](base, s)
+
+    return len(base)


### PR DESCRIPTION
Returns a `pd.Series` with the intersection counts as values:

```python
a = set(['a', 'b', 'c', 'f'])
b = set(['a', 'b', 'd'])
c = set(['a', 'b', 'd', 'e', 'f'])
d = set(['a', 'b', 'z'])

data = {'s1': a, 's2': b, 's3': c, 's4': d}

upset = upsetplot.data.from_sets(ds)
```

Returns:
```
s1     s2     s3     s4   
True   True   True   True     2
                     False    0
              False  True     0
                     False    0
       False  True   True     0
                     False    1
              False  True     0
                     False    1
False  True   True   True     0
                     False    1
              False  True     0
                     False    0
       False  True   True     0
                     False    1
              False  True     1
                     False    0
dtype: int64
```