### PR TITLE
Intersection ratio

### DIFF
--- a/examples/plot_generated.py
+++ b/examples/plot_generated.py
@@ -20,6 +20,6 @@ plot(example, sort_by='cardinality')
 plt.suptitle('Ordered by cardinality')
 plt.show()
 
-plot(example, show_counts='%d')
+plot(example, show_counts=True)
 plt.suptitle('With counts shown')
 plt.show()

--- a/examples/plot_vertical.py
+++ b/examples/plot_vertical.py
@@ -14,6 +14,6 @@ plot(example, orientation='vertical')
 plt.suptitle('A vertical plot')
 plt.show()
 
-plot(example, orientation='vertical', show_counts='%d')
+plot(example, orientation='vertical', show_counts=True)
 plt.suptitle('A vertical plot with counts shown')
 plt.show()

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -269,9 +269,12 @@ class UpSet:
         The totals plot should be large enough to fit this many matrix
         elements.
     show_counts : bool or str, default=False
-        Whether to label the intersection size bars with the cardinality or
-        percentage of the intersection. Accepts "cardinality" (equivalent to
-        True) or "percent"
+        Whether to label the intersection size bars with the cardinality (or
+        percent if `counts_as_percent` is specified) of the intersection. When
+        a string, this formats the number.  For example, '%d' is equivalent to
+        True.
+    counts_as_percent : bool, default=False
+        If the intersection counts should be displayed as a percentage.
     sort_sets_by
         .. deprecated: 0.3
             Replaced by sort_categories_by, this parameter will be removed in
@@ -285,7 +288,8 @@ class UpSet:
                  facecolor='black',
                  with_lines=True, element_size=32,
                  intersection_plot_elements=6, totals_plot_elements=2,
-                 show_counts=False, sort_sets_by='deprecated'):
+                 show_counts=False, counts_as_percent=False,
+                 sort_sets_by='deprecated'):
 
         self._horizontal = orientation == 'horizontal'
         self._reorient = _identity if self._horizontal else _transpose
@@ -296,14 +300,8 @@ class UpSet:
         self._subset_plots = [{'type': 'default',
                                'id': 'intersections',
                                'elements': intersection_plot_elements}]
-        if show_counts not in (True, False, 'cardinality', 'percent'):
-            raise ValueError(
-                'show_counts must be bool, "cardinality", or "percent"'
-            )
-        if show_counts is True:
-            show_counts = 'cardinality'
-
         self._show_counts = show_counts
+        self._counts_as_percent = counts_as_percent
 
         if sort_sets_by != 'deprecated':
             sort_categories_by = sort_sets_by
@@ -499,11 +497,11 @@ class UpSet:
                        .5, color=self._facecolor, zorder=10, align='center')
 
         values = self.intersections
-        if self._show_counts == 'cardinality':
-            fmt = '%d'
-        else:
+        if self._counts_as_percent:
             values = 100 * (values / values.sum())
-            fmt = '%.1f%%'
+            fmt = '%.1f%%' if self._show_counts is True else self._show_counts
+        else:
+            fmt = '%d' if self._show_counts is True else self._show_counts
 
         self._label_sizes(ax, rects, 'top' if self._horizontal else 'right',
                           fmt=fmt, values=values)

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -285,7 +285,7 @@ class UpSet:
                  facecolor='black',
                  with_lines=True, element_size=32,
                  intersection_plot_elements=6, totals_plot_elements=2,
-                 show_counts='', sort_sets_by='deprecated'):
+                 show_counts=False, sort_sets_by='deprecated'):
 
         self._horizontal = orientation == 'horizontal'
         self._reorient = _identity if self._horizontal else _transpose

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -499,7 +499,14 @@ class UpSet:
         rects = ax.bar(np.arange(len(intersections)), intersections,
                        .5, color=self._facecolor, zorder=10, align='center')
 
-        self._label_sizes(ax, rects, 'top' if self._horizontal else 'right')
+        if self._show_counts is True and self.normalize_counts:
+            fmt = '%.2f'
+        elif self._show_counts is True and not self.normalize_counts:
+            fmt = '%d'
+        else:
+            fmt = self._show_counts
+        self._label_sizes(ax, rects, 'top' if self._horizontal else 'right',
+                          fmt)
 
         ax.xaxis.set_visible(False)
         for x in ['top', 'bottom', 'right']:
@@ -507,17 +514,15 @@ class UpSet:
 
         tick_axis = ax.yaxis
         tick_axis.grid(True)
-        ax.set_ylabel('Intersection size')
+        ax.set_ylabel(
+            'Intersection {}'.format(
+                'Fraction' if self.normalize_counts else 'Size'
+            )
+        )
 
-    def _label_sizes(self, ax, rects, where):
+    def _label_sizes(self, ax, rects, where, fmt='%d'):
         if not self._show_counts:
             return
-        if self._show_counts is True and self.normalize_counts:
-            fmt = '%.2f'
-        elif self._show_counts is True and not self.normalize_counts:
-            fmt = '%d'
-        else:
-            fmt = self._show_counts
         if where == 'right':
             margin = 0.01 * abs(np.diff(ax.get_xlim()))
             for rect in rects:

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -499,8 +499,13 @@ class UpSet:
         values = self.intersections
         if self.normalize_counts:
             values = 100 * (values / values.sum())
+
+        if self.normalize_counts:
+            fmt = '%.1f%%'
+        else:
+            fmt = None
         self._label_sizes(ax, rects, 'top' if self._horizontal else 'right',
-                          values=values)
+                          fmt=fmt, values=values)
 
         ax.xaxis.set_visible(False)
         for x in ['top', 'bottom', 'right']:
@@ -555,8 +560,7 @@ class UpSet:
         ax = self._reorient(ax)
         rects = ax.barh(np.arange(len(self.totals.index.values)), self.totals,
                         .5, color=self._facecolor, align='center')
-        self._label_sizes(ax, rects, 'left' if self._horizontal else 'top',
-                          '%d')
+        self._label_sizes(ax, rects, 'left' if self._horizontal else 'top')
 
         max_total = self.totals.max()
         if self._horizontal:

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -398,7 +398,8 @@ def test_show_counts(orientation):
     assert n_artists_yes_sizes - n_artists_no_sizes > 6
 
     fig = matplotlib.figure.Figure()
-    plot(X, fig, orientation=orientation, show_counts='percent')
+    plot(X, fig, orientation=orientation, show_counts=True,
+         counts_as_percent=True)
     assert n_artists_yes_sizes == _count_descendants(fig)
 
     with pytest.raises(ValueError):

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -398,7 +398,7 @@ def test_show_counts(orientation):
     assert n_artists_yes_sizes - n_artists_no_sizes > 6
 
     fig = matplotlib.figure.Figure()
-    plot(X, fig, show_counts='%0.2g')
+    plot(X, fig, show_counts='percent')
     assert n_artists_yes_sizes == _count_descendants(fig)
 
     with pytest.raises(ValueError):

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -389,16 +389,16 @@ def _count_descendants(el):
 def test_show_counts(orientation):
     fig = matplotlib.figure.Figure()
     X = generate_counts(n_samples=100)
-    plot(X, fig)
+    plot(X, fig, orientation=orientation)
     n_artists_no_sizes = _count_descendants(fig)
 
     fig = matplotlib.figure.Figure()
-    plot(X, fig, show_counts=True)
+    plot(X, fig, orientation=orientation, show_counts=True)
     n_artists_yes_sizes = _count_descendants(fig)
     assert n_artists_yes_sizes - n_artists_no_sizes > 6
 
     fig = matplotlib.figure.Figure()
-    plot(X, fig, show_counts='percent')
+    plot(X, fig, orientation=orientation, show_counts='percent')
     assert n_artists_yes_sizes == _count_descendants(fig)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds the ability to normalize counts by adding a `normalize_counts` parameter to the `UpSet` constructor.

For example:

```python3
import upsetplot

example = upsetplot.generate_counts()
upsetplot.plot(example, normalize_counts=True, show_counts=True)
```
![counts_pr](https://user-images.githubusercontent.com/1536907/65527894-7258fe00-dec1-11e9-8747-ef7e264c3043.png)