### PR TITLE
allow arbitrary data order

### DIFF
--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -106,7 +106,7 @@ def _process_data(df, sort_by, sort_categories_by, subset_size, sum_over):
     elif sort_by == 'degree':
         gb_degree = agg.groupby(sum, group_keys=False)
         agg = gb_degree.apply(lambda x: x.sort_index(ascending=False))
-    elif sort_by is None:
+    elif sort_by == 'given':
         pass
     else:
         raise ValueError('Unknown sort_by: %r' % sort_by)
@@ -205,10 +205,11 @@ class UpSet:
         If a DataFrame, `sum_over` must be a string or False.
     orientation : {'horizontal' (default), 'vertical'}
         If horizontal, intersections are listed from left to right.
-    sort_by : {'cardinality', 'degree'}
+    sort_by : {'cardinality', 'degree', 'given'}
         If 'cardinality', subset are listed from largest to smallest.
         If 'degree', they are listed in order of the number of categories
-        intersected.
+        intersected. If 'given', the order they appear in the data input is
+        used.
     sort_categories_by : {'cardinality', None}
         Whether to sort the categories by total cardinality, or leave them
         in the provided order.

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -52,7 +52,7 @@ def _aggregate_data(df, subset_size, sum_over):
                                  'subset_size="sum" and a DataFrame is '
                                  'provided.')
 
-    gb = df.groupby(level=list(range(df.index.nlevels)))
+    gb = df.groupby(level=list(range(df.index.nlevels)), sort=False)
     if sum_over is False:
         aggregated = gb.size()
         aggregated.name = 'size'
@@ -106,6 +106,8 @@ def _process_data(df, sort_by, sort_categories_by, subset_size, sum_over):
     elif sort_by == 'degree':
         gb_degree = agg.groupby(sum, group_keys=False)
         agg = gb_degree.apply(lambda x: x.sort_index(ascending=False))
+    elif sort_by is None:
+        pass
     else:
         raise ValueError('Unknown sort_by: %r' % sort_by)
 

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -238,7 +238,6 @@ def test_not_unique(sort_by, sort_categories_by):
 
 @pytest.mark.parametrize('kw', [{'sort_by': 'blah'},
                                 {'sort_by': True},
-                                {'sort_by': None},
                                 {'sort_categories_by': 'blah'},
                                 {'sort_categories_by': True}])
 def test_param_validation(kw):


### PR DESCRIPTION
This small PR allows the data to be displayed in the arbitrary order in which it was input rather than needing to be sorted by cardinality or degree.