### PR TITLE
Fix large x-axis plot margins with high number of unique intersections

### DIFF
--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -461,7 +461,7 @@ class UpSet:
         if not self._horizontal:
             ax.yaxis.set_ticks_position('top')
         ax.set_frame_on(False)
-        ax.set_xlim(xmin=.5, xmax=x[-1]+.5, auto=False)
+        ax.set_xlim(xmin=.5, xmax=x[-1] + .5, auto=False)
 
     def plot_intersections(self, ax):
         """Plot bars indicating intersection size

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -461,6 +461,7 @@ class UpSet:
         if not self._horizontal:
             ax.yaxis.set_ticks_position('top')
         ax.set_frame_on(False)
+        ax.set_xlim(xmin=.5, xmax=x[-1]+.5, auto=False)
 
     def plot_intersections(self, ax):
         """Plot bars indicating intersection size

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -467,6 +467,7 @@ class UpSet:
         """Plot bars indicating intersection size
         """
         ax = self._reorient(ax)
+        ax.set_autoscalex_on(False)
         rects = ax.bar(np.arange(len(self.intersections)), self.intersections,
                        .5, color=self._facecolor, zorder=10, align='center')
 

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -442,3 +442,19 @@ def test_index_must_be_bool(x):
     x = x.set_index(['cat0', 'cat1', 'cat2']).iloc[:, 0]
     with pytest.raises(ValueError, match='not boolean'):
         UpSet(x)
+
+
+@pytest.mark.parametrize('x', [
+    generate_counts(n_categories=3),
+    generate_counts(n_categories=8),
+    generate_counts(n_categories=15),
+])
+def test_matrix_plot_margins(x):
+    """Non-regression test addressing a bug where there is are large whitespace
+       margins around the matrix when the number of intersections is large"""
+    axes = plot(x)
+
+    # Expected behavior is that each matrix column takes up one unit on x-axis
+    expected = len(x) - 1
+    actual = axes['matrix'].get_xlim()[1] - axes['matrix'].get_xlim()[0]
+    assert expected == actual


### PR DESCRIPTION
When the number of unique intersections is large, a horizontal gap forms between the vertical axis and the start of the matrix/intersection bars (see screenshots). The gap arises from the autoscaling behavior of the Axes object containing the matrix plot, which adds a significant margin to the view limits of the x-axis proportional to the range of the plotted objects. This PR disables the autoscaling behavior and fixes the view limit of the x axis with a constant margin around the plotted elements.

![Screen Shot 2020-09-25 at 12 54 36 AM](https://user-images.githubusercontent.com/6352240/94230389-dac12d80-fecf-11ea-9771-3e8a6ebcd5ad.png)
![before](https://user-images.githubusercontent.com/6352240/94230559-3ab7d400-fed0-11ea-9200-a0b46002322a.png)
![after](https://user-images.githubusercontent.com/6352240/94230600-502cfe00-fed0-11ea-834d-4e720300e46c.png)

