### PR TITLE
Record the license in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def setup_package():
         setup(name='UpSetPlot',
               version=version,
               packages=["upsetplot"],
+              license=['BSD-3-Clause'],
               setup_requires=['pytest-runner'],
               tests_require=['pytest>=2.7', 'pytest-cov<2.6'],
               # TODO: check versions


### PR DESCRIPTION
This is useful for tools that inspect the license of installed Python packages.

This uses the official OSI short name for the license posted in the LICENSE file.