### PR TITLE
Properly import LooseVersion

### DIFF
--- a/upsetplot/data.py
+++ b/upsetplot/data.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from numbers import Number
 import functools
-import distutils
+from distutils.version import LooseVersion
 import warnings
 
 import pandas as pd
@@ -375,7 +375,7 @@ def from_contents(contents, data=None, id_column='id'):
         raise ValueError('Got duplicate ids in a category')
 
     concat = pd.concat
-    if distutils.version.LooseVersion(pd.__version__) >= '0.23.0':
+    if LooseVersion(pd.__version__) >= '0.23.0':
         # silence the warning
         concat = functools.partial(concat, sort=False)
 


### PR DESCRIPTION
Importing distutils will cause a name clash with the later call in newer versions of setuptools (observed on Python 3.9.9):

```
============================= test session starts ==============================                                                                                                      
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /gnu/store/j3cx0yaqdpw0mxizp5bayx93pya44dhn-python-wrapper-3.9.9/bin/python                                 
cachedir: .pytest_cache                                                                                                                                                               
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/tmp/guix-build-python-upsetplot-0.6.0.drv-0/UpSetPlot-0.6.0/.hypothesis/examples')                           
rootdir: /tmp/guix-build-python-upsetplot-0.6.0.drv-0/UpSetPlot-0.6.0, configfile: setup.cfg, testpaths: upsetplot, README.rst                                                        
plugins: hypothesis-6.0.2, cov-2.8.1                                                      
collecting ... collected 4 items
[...]
=================================== FAILURES ===================================
____________________ [doctest] upsetplot.data.from_contents ____________________
340     The order of categories in the output DataFrame is determined from
341     `contents`, which may have non-deterministic iteration order.
342
343     Examples
344     --------
345     >>> from upsetplot import from_contents
346     >>> contents = {'cat1': ['a', 'b', 'c'],
347     ...             'cat2': ['b', 'd'],
348     ...             'cat3': ['e']}
349     >>> from_contents(contents)
UNEXPECTED EXCEPTION: AttributeError("module 'distutils' has no attribute 'version'")
Traceback (most recent call last):
  File "/gnu/store/b6j1qw1a5rkbfvcy7lc9fm95abbzpa4x-python-3.9.9/lib/python3.9/doctest.py", line 1334, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest upsetplot.data.from_contents[2]>", line 1, in <module>
  File "/tmp/guix-build-python-upsetplot-0.6.0.drv-0/UpSetPlot-0.6.0/upsetplot/data.py", line 378, in from_contents
    if distutils.version.LooseVersion(pd.__version__) >= '0.23.0':
AttributeError: module 'distutils' has no attribute 'version'
/tmp/guix-build-python-upsetplot-0.6.0.drv-0/UpSetPlot-0.6.0/upsetplot/data.py:349: UnexpectedException

----------- coverage: platform linux, python 3.9.9-final-0 -----------
Name                    Stmts   Miss  Cover
-------------------------------------------
upsetplot/__init__.py       6      0   100%
upsetplot/data.py         112     35    69%
upsetplot/plotting.py     443    398    10%
-------------------------------------------
TOTAL                     561    433    23%

=========================== short test summary info ============================
FAILED upsetplot/data.py::upsetplot.data.from_contents
========================= 1 failed, 3 passed in 1.82s ==========================
```