### PR TITLE
Functionality to style axes based on keys

### DIFF
--- a/examples/plot_highlight.py
+++ b/examples/plot_highlight.py
@@ -3,7 +3,8 @@
 Highlighting selected subsets
 =============================
 
-Demonstrates use of the `style_subsets` and `style_axes` method to mark some subsets or style axes differently.
+Demonstrates use of the `style_subsets` and `style_axes` method
+to mark some subsets or style axes differently.
 
 """
 

--- a/examples/plot_highlight.py
+++ b/examples/plot_highlight.py
@@ -3,8 +3,7 @@
 Highlighting selected subsets
 =============================
 
-Demonstrates use of the `style_subsets` method to mark some subsets as
-different.
+Demonstrates use of the `style_subsets` and `style_axes` method to mark some subsets or style axes differently.
 
 """
 
@@ -62,3 +61,51 @@ with plt.rc_context(params):
     upset.plot()
 plt.suptitle("Styles for every category!")
 plt.show()
+
+
+##########################################################################
+# Axes can be styled similar to subplots, by name.
+# ... with fill color
+
+upset = UpSet(example)
+upset.style_axes(axes_names=["cat2"],
+                 facecolor=(0, 0, 1, 0.3))
+plt.suptitle("Paint axes with fill color")
+upset.plot()
+
+##########################################################################
+# ... or edgecolor.
+
+upset = UpSet(example)
+upset.style_axes(axes_names=["cat0"],
+                 facecolor=(0, 1, 0, 0.3),
+                 edgecolor="red",
+                 linestyle="-",
+                 linewidth=2)
+upset.style_axes(axes_names=["cat1"],
+                 facecolor=(1, 0, 0, 0.3),
+                 edgecolor="green",
+                 linestyle="--",
+                 linewidth=1)
+plt.suptitle("Border for axes")
+upset.plot()
+
+##########################################################################
+# Multiple stylings can be applied with different criteria in the same
+# plot.
+
+upset = UpSet(example)
+upset.style_axes(axes_names=["cat2"],
+                 facecolor=(0, 0, 1, 0.3))
+upset.style_axes(axes_names=["cat0"],
+                 facecolor=(0, 1, 0, 0.3),
+                 edgecolor="red",
+                 linestyle="-",
+                 linewidth=2)
+upset.style_axes(axes_names=["cat1"],
+                 facecolor=(1, 0, 0, 0.3),
+                 edgecolor="green",
+                 linestyle="--",
+                 linewidth=1)
+plt.suptitle("Combine all the stylings!")
+upset.plot()

--- a/examples/plot_highlight.py
+++ b/examples/plot_highlight.py
@@ -69,44 +69,47 @@ plt.show()
 # ... with fill color
 
 upset = UpSet(example)
-upset.style_axes(axes_names=["cat2"],
-                 facecolor=(0, 0, 1, 0.3))
-plt.suptitle("Paint axes with fill color")
+upset.style_categories(category_names=["cat2"],
+                       facecolor=(0, 0, 1, 0.3))
 upset.plot()
+plt.suptitle("Style categories with fill color")
+plt.show()
 
 ##########################################################################
 # ... or edgecolor.
 
 upset = UpSet(example)
-upset.style_axes(axes_names=["cat0"],
-                 facecolor=(0, 1, 0, 0.3),
-                 edgecolor="red",
-                 linestyle="-",
-                 linewidth=2)
-upset.style_axes(axes_names=["cat1"],
-                 facecolor=(1, 0, 0, 0.3),
-                 edgecolor="green",
-                 linestyle="--",
-                 linewidth=1)
-plt.suptitle("Border for axes")
+upset.style_categories(category_names=["cat0"],
+                       facecolor=(0, 1, 0, 0.3),
+                       edgecolor="red",
+                       linestyle="-",
+                       linewidth=2)
+upset.style_categories(category_names=["cat1"],
+                       facecolor=(1, 0, 0, 0.3),
+                       edgecolor="green",
+                       linestyle="--",
+                       linewidth=1)
 upset.plot()
+plt.suptitle("Border styles for categories")
+plt.show()
 
 ##########################################################################
 # Multiple stylings can be applied with different criteria in the same
 # plot.
 
 upset = UpSet(example)
-upset.style_axes(axes_names=["cat2"],
-                 facecolor=(0, 0, 1, 0.3))
-upset.style_axes(axes_names=["cat0"],
-                 facecolor=(0, 1, 0, 0.3),
-                 edgecolor="red",
-                 linestyle="-",
-                 linewidth=2)
-upset.style_axes(axes_names=["cat1"],
-                 facecolor=(1, 0, 0, 0.3),
-                 edgecolor="green",
-                 linestyle="--",
-                 linewidth=1)
-plt.suptitle("Combine all the stylings!")
+upset.style_categories(category_names=["cat2"],
+                       facecolor=(0, 0, 1, 0.3))
+upset.style_categories(category_names=["cat0"],
+                       facecolor=(0, 1, 0, 0.3),
+                       edgecolor="red",
+                       linestyle="-",
+                       linewidth=2)
+upset.style_categories(category_names=["cat1"],
+                       facecolor=(1, 0, 0, 0.3),
+                       edgecolor="green",
+                       linestyle="--",
+                       linewidth=1)
 upset.plot()
+plt.suptitle("Combine all the stylings!")
+plt.show()

--- a/test_example.py
+++ b/test_example.py
@@ -1,0 +1,29 @@
+# %%
+import upsetplot as ups
+import matplotlib.pyplot as plt
+
+example = ups.generate_counts(seed=1, n_samples=1000, n_categories=4)
+
+##########################################################################
+# Axes can be styled similar to subplots, by name.
+# ... with fill color
+
+fig = plt.figure(dpi=400)
+
+upset = ups.UpSet(example, sort_by="cardinality", min_subset_size=50)
+# upset.style_axes(axes_names=["cat2"],
+#                  facecolor=(0, 0, 1, 0.3))
+upset.style_categories(category_names=["cat3"],
+                       facecolor=(0, 1, 0, 0.3),
+                       #  edgecolor="red",
+                       #  linestyle="-",
+                       linewidth=2)
+upset.style_categories(category_names=["cat1"],
+                       facecolor=(1, 0, 0, 0.3),
+                       #  edgecolor="green",
+                       #  linestyle="--",
+                       linewidth=1)
+upset.style_subsets(present=["cat1", "cat3"], facecolor="red")
+plt.suptitle("Make a point...")
+upset.plot(fig)
+plt.savefig("styling.jpg", dpi=300)

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -275,8 +275,8 @@ class UpSet:
                                       min_degree=min_degree,
                                       max_degree=max_degree,
                                       reverse=not self._horizontal)
-        self.axes_styles = {k: {"facecolor": self._shading_color}
-                            for k in self.totals.index}
+        self.category_styles = {k: {"facecolor": self._shading_color}
+                                for k in self.totals.index}
         self.subset_styles = [{"facecolor": facecolor}
                               for i in range(len(self.intersections))]
         self.subset_legend = []  # pairs of (style, label)
@@ -784,16 +784,16 @@ class UpSet:
             visible = i % 2 == 0
             ls = "-"
             lw = 0
-            if name in self.axes_styles:
-                shading_color = self.axes_styles[name].get(
+            if name in self.category_styles:
+                shading_color = self.category_styles[name].get(
                     "facecolor", self._shading_color)
-                ls = self.axes_styles[name].get("linestyle", "-")
-                lw = self.axes_styles[name].get("linewidth", 0)
+                ls = self.category_styles[name].get("linestyle", "-")
+                lw = self.category_styles[name].get("linewidth", 0)
                 if lw:
                     start += (lw / (self._default_figsize[0] * self.DPI))
                     # 2 is not enough, 3 is visually more appealing.
                     end -= (lw / (self._default_figsize[0] * self.DPI)) * 3
-                edgecolor = self.axes_styles[name].get("edgecolor", None)
+                edgecolor = self.category_styles[name].get("edgecolor", None)
                 visible = 1
             rect = plt.Rectangle(
                 self._swapaxes(start, i - 0.4),
@@ -822,16 +822,16 @@ class UpSet:
         ax.set_xticklabels([])
         ax.set_yticklabels([])
 
-    def style_axes(self, axes_names, facecolor=None,
-                   edgecolor=None, linewidth=None, linestyle=None):
-        """Updates the style of axes names
+    def style_categories(self, category_names, facecolor=None,
+                         edgecolor=None, linewidth=None, linestyle=None):
+        """Updates the style of the categories.
 
         Parameters are either used to select them by name, or to style them
         with attributes of :class:`matplotlib.patches.Patch`.
 
         Parameters
         ----------
-        axes_names : list[str] axes index names.
+        category_names : list[str] category names.
             Axes names where the changed style is applied.
         facecolor : str or RGBA matplotlib color tuple, optional.
             RGBA (red, green, blue, alpha) tuple of float values
@@ -847,7 +847,9 @@ class UpSet:
         style = {"facecolor": facecolor, "edgecolor": edgecolor,
                  "linewidth": linewidth, "linestyle": linestyle}
         style = {k: v for k, v in style.items() if v is not None}
-        self.axes_styles.update({axes_name: style for axes_name in axes_names})
+        self.category_styles.update(
+            {category_name: style for category_name in category_names}
+        )
 
     def plot(self, fig=None):
         """Draw all parts of the plot onto fig or a new figure

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -800,8 +800,7 @@ class UpSet:
                 ls=ls,
                 lw=lw,
                 zorder=0,
-                visible=visible,
-            )
+                visible=visible)
 
             ax.add_patch(rect)
         ax.set_frame_on(False)

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -826,15 +826,15 @@ class UpSet:
                    edgecolor=None, linewidth=None, linestyle=None):
         """Updates the style of axes names
 
-        Parameters are either used to select them by name, or to style them 
+        Parameters are either used to select them by name, or to style them
         with attributes of :class:`matplotlib.patches.Patch`.
 
         Parameters
         ----------
         axes_names : list[str] axes index names.
             Axes names where the changed style is applied.
-        facecolor : str or RGBA matplotlib color tuple, optional. 
-            RGBA (red, green, blue, alpha) tuple of float values 
+        facecolor : str or RGBA matplotlib color tuple, optional.
+            RGBA (red, green, blue, alpha) tuple of float values
             in [0, 1] (e.g., (0.1, 0.2, 0.5, 0.3)).
             Override the default UpSet facecolor for selected subsets.
         edgecolor : str or matplotlib color, optional

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -275,7 +275,8 @@ class UpSet:
                                       min_degree=min_degree,
                                       max_degree=max_degree,
                                       reverse=not self._horizontal)
-        self.axes_styles = {k: {"facecolor": self._shading_color} for k in self.totals.index}
+        self.axes_styles = {k: {"facecolor": self._shading_color}
+                            for k in self.totals.index}
         self.subset_styles = [{"facecolor": facecolor}
                               for i in range(len(self.intersections))]
         self.subset_legend = []  # pairs of (style, label)
@@ -784,12 +785,14 @@ class UpSet:
             ls = "-"
             lw = 0
             if name in self.axes_styles:
-                shading_color = self.axes_styles[name].get("facecolor", self._shading_color)
+                shading_color = self.axes_styles[name].get(
+                    "facecolor", self._shading_color)
                 ls = self.axes_styles[name].get("linestyle", "-")
                 lw = self.axes_styles[name].get("linewidth", 0)
                 if lw:
                     start += (lw / (self._default_figsize[0] * self.DPI))
-                    end -= (lw / (self._default_figsize[0] * self.DPI)) * 3  # 2 is not enough, 3 is visually more appealing.
+                    # 2 is not enough, 3 is visually more appealing.
+                    end -= (lw / (self._default_figsize[0] * self.DPI)) * 3
                 edgecolor = self.axes_styles[name].get("edgecolor", None)
                 visible = 1
             rect = plt.Rectangle(
@@ -823,14 +826,16 @@ class UpSet:
                    edgecolor=None, linewidth=None, linestyle=None):
         """Updates the style of axes names
 
-        Parameters are either used to select them by name, or to style them with
-        attributes of :class:`matplotlib.patches.Patch`.
+        Parameters are either used to select them by name, or to style them 
+        with attributes of :class:`matplotlib.patches.Patch`.
 
         Parameters
         ----------
         axes_names : list[str] axes index names.
             Axes names where the changed style is applied.
-        facecolor : str or RGBA matplotlib color tuple, optional. RGBA (red, green, blue, alpha) tuple of float values in [0, 1] (e.g., (0.1, 0.2, 0.5, 0.3)).
+        facecolor : str or RGBA matplotlib color tuple, optional. 
+            RGBA (red, green, blue, alpha) tuple of float values 
+            in [0, 1] (e.g., (0.1, 0.2, 0.5, 0.3)).
             Override the default UpSet facecolor for selected subsets.
         edgecolor : str or matplotlib color, optional
             Set the edgecolor for bars, dots, and the line between dots.

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -819,7 +819,7 @@ class UpSet:
         ax.set_xticklabels([])
         ax.set_yticklabels([])
 
-    def style_axes(self, axes_names: list[str], facecolor=None,
+    def style_axes(self, axes_names, facecolor=None,
                    edgecolor=None, linewidth=None, linestyle=None):
         """Updates the style of axes names
 
@@ -828,6 +828,8 @@ class UpSet:
 
         Parameters
         ----------
+        axes_names : list[str] axes index names.
+            Axes names where the changed style is applied.
         facecolor : str or RGBA matplotlib color tuple, optional. RGBA (red, green, blue, alpha) tuple of float values in [0, 1] (e.g., (0.1, 0.2, 0.5, 0.3)).
             Override the default UpSet facecolor for selected subsets.
         edgecolor : str or matplotlib color, optional


### PR DESCRIPTION
I wanted to highlight the axes, to indicate missing or excessive occurrences of some keys.
However, I could find this neither in the docs nor in the code, so I included `style_axes` and updated `style_shading` accordingly. If you, @jnothman, can find a more descriptive name for this function, I'm happy, but I couldn't come up with one...

The result can be seen here:

![styling](https://user-images.githubusercontent.com/28198620/151551827-25dc3e45-629b-4a4e-bcb9-6b41298597a5.jpg)

