### PR TITLE
Fix RTD formatting for docstring examples

### DIFF
--- a/upsetplot/data.py
+++ b/upsetplot/data.py
@@ -130,6 +130,7 @@ def from_indicators(indicators, data=None):
     >>> from upsetplot import from_indicators
 
     Just indicators
+
     >>> indicators = {"cat1": [True, False, True, False],
     ...               "cat2": [False, True, False, False],
     ...               "cat3": [True, True, False, False]}
@@ -142,6 +143,7 @@ def from_indicators(indicators, data=None):
     Name: ones, dtype: float64
 
     Where indicators are included within data, specifying columns by name
+
     >>> data = pd.DataFrame({"value": [5, 4, 6, 4], **indicators})
     >>> from_indicators(["cat1", "cat3"], data=data)
                  value   cat1   cat2   cat3
@@ -152,6 +154,7 @@ def from_indicators(indicators, data=None):
     False False      4  False  False  False
 
     Making indicators out of all boolean columns
+
     >>> from_indicators(lambda data: data.select_dtypes(bool), data=data)
                        value   cat1   cat2   cat3
     cat1  cat2  cat3
@@ -161,6 +164,7 @@ def from_indicators(indicators, data=None):
     False False False      4  False  False  False
 
     Using a dataset with missing data, we can use missingness as an indicator
+
     >>> data = pd.DataFrame({"val1": [pd.NA, .7, pd.NA, .9],
     ...                      "val2": ["male", pd.NA, "female", "female"],
     ...                      "val3": [pd.NA, pd.NA, 23000, 78000]})

--- a/upsetplot/reformat.py
+++ b/upsetplot/reformat.py
@@ -255,7 +255,8 @@ def query(data, present=None, absent=None,
               False      2  2.05...
               False     10  2.55...
 
-    # sorting
+    Sorting
+
     >>> query(data, min_degree=1, sort_by="degree").subset_sizes
     cat1   cat2   cat0
     True   False  False    11


### PR DESCRIPTION
The formatting of some the example docstring codeblocks on https://upsetplot.readthedocs.io/en/latest/api.html is incorrect, probably due to blank lines causing Sphinx to think it's the end of the block? Adding extra blank lines seems to fix it when I build it locally.