### PR TITLE
Fixed issue: matplotlib.tight_layout restricts matplotlib version to 3.5.2 (#191)

### DIFF
--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -178,7 +178,8 @@ def test_process_data_frame(x, sort_by, sort_categories_by):
     assert_array_equal(df3['b'], X['b'])
 
     # check subset_size='count'
-    X = pd.DataFrame({'b': np.ones(len(x), dtype=int), 'c': x})
+    X = pd.DataFrame({'b': np.ones(len(x), dtype='int64'), 'c': x})
+
     total4, df4, intersections4, totals4 = _process_data(
         X, sort_by=sort_by, sort_categories_by=sort_categories_by,
         sum_over='b', subset_size='auto')


### PR DESCRIPTION
The changes below should allow UpSetPlot to support matplotlib versions both above and below 3.5.2, fixing issue #191:

matplotlib.tight_layout.get_renderer is no longer imported when matplotlib version is >3.5.2, as it has been deprecated in matplotlib>3.5.2, and is no longer required in these versions when calling get_window_extent().  

get_window_extent no longer takes argument 'renderer' when matplotlib version is >3.5.2 (as appropriate for matplotlib>3.5.2 changes). 

All tests passed on my setup (Windows 10, Python 3.9, matplotlib version 3.6.1). 