### PR TITLE
Fix handling of #categories > 63

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ What's new in version 0.8
 - Allowed ``show_percentages`` to be provided with a custom formatting string,
   for example to show more decimal places. (:issue:`194`)
 - Added `subsets` attribute to QueryResult. (:issue:`198`)
+- Fixed a bug where more than 64 categories could result in an error. (:issue:`193`)
 
 What's new in version 0.7
 -------------------------

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -42,7 +42,9 @@ def _process_data(df, sort_by, sort_categories_by, subset_size,
     # XXX: ugly!
     def _pack_binary(X):
         X = pd.DataFrame(X)
-        out = 0
+        # we use objects when there are many categories for arbitrary precision integers
+        dtype = np.object if X.shape[1] > 63 else np.uint64
+        out = pd.Series(0, index=X.index, dtype=dtype)
         for i, (_, col) in enumerate(X.items()):
             out *= 2
             out += col

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -42,7 +42,7 @@ def _process_data(df, sort_by, sort_categories_by, subset_size,
     # XXX: ugly!
     def _pack_binary(X):
         X = pd.DataFrame(X)
-        # we use objects when there are many categories for arbitrary precision integers
+        # use objects if arbitrary precision integers are needed
         dtype = np.object if X.shape[1] > 62 else np.uint64
         out = pd.Series(0, index=X.index, dtype=dtype)
         for i, (_, col) in enumerate(X.items()):

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -43,7 +43,7 @@ def _process_data(df, sort_by, sort_categories_by, subset_size,
     def _pack_binary(X):
         X = pd.DataFrame(X)
         # we use objects when there are many categories for arbitrary precision integers
-        dtype = np.object if X.shape[1] > 63 else np.uint64
+        dtype = np.object if X.shape[1] > 62 else np.uint64
         out = pd.Series(0, index=X.index, dtype=dtype)
         for i, (_, col) in enumerate(X.items()):
             out *= 2

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -43,7 +43,7 @@ def _process_data(df, sort_by, sort_categories_by, subset_size,
     def _pack_binary(X):
         X = pd.DataFrame(X)
         # use objects if arbitrary precision integers are needed
-        dtype = np.object if X.shape[1] > 62 else np.uint64
+        dtype = np.object_ if X.shape[1] > 62 else np.uint64
         out = pd.Series(0, index=X.index, dtype=dtype)
         for i, (_, col) in enumerate(X.items()):
             out *= 2

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -915,3 +915,15 @@ def test_style_subsets_artists(orientation):
 
     # TODO: check lines between dots
     # matrix_line_collection = upset_axes["matrix"].collections[1]
+
+
+def test_many_categories():
+    # Tests regressions against GH#193
+    n_cats = 250
+    index1 = [True, False] + [False] * (n_cats - 2)
+    index2 = [False, True] + [False] * (n_cats - 2)
+    columns = [chr(i + 33) for i in range(n_cats)]
+    data = pd.DataFrame([index1, index2], columns=columns)
+    data["value"] = 1
+    data = data.set_index(columns)["value"]
+    UpSet(data)


### PR DESCRIPTION
Fixes #193 by using arbitrary precision integers in `_pack_binary` if needed.