### PR TITLE
Example of using thousands separator in show_counts

### DIFF
--- a/examples/plot_generated.py
+++ b/examples/plot_generated.py
@@ -27,8 +27,8 @@ plt.show()
 
 ##########################################################################
 
-plot(example, show_counts="{:d}")
-plt.suptitle("With counts shown")
+plot(example, show_counts="{:,}")
+plt.suptitle("With counts shown, using a thousands separator")
 plt.show()
 
 ##########################################################################


### PR DESCRIPTION
Fixes #114