### PR TITLE
Tiny changes to four DataFrames to make them Pandas future-compliant

### DIFF
--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -792,10 +792,10 @@ class UpSet:
                 }
             )
         )
-        styles["linewidth"].fillna(1, inplace=True)
-        styles["facecolor"].fillna(self._facecolor, inplace=True)
-        styles["edgecolor"].fillna(styles["facecolor"], inplace=True)
-        styles["linestyle"].fillna("solid", inplace=True)
+        styles["linewidth"]=styles["linewidth"].fillna(1)
+        styles["facecolor"]=styles["facecolor"].fillna(self._facecolor)
+        styles["edgecolor"]=styles["edgecolor"].fillna(styles["facecolor"])
+        styles["linestyle"]=styles["linestyle"].fillna("solid")
         del styles["hatch"]  # not supported in matrix (currently)
 
         x = np.repeat(np.arange(len(data)), n_cats)


### PR DESCRIPTION
These tiny changes, though not esthetically pleasing, address the following FutureWarning by removing the deprecated inplace option:

"FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method. The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.

  styles["linewidth"].fillna(1, inplace=True)"
(a similar warning is generated for each of three lines)