### PR TITLE
Fix issues related to matplotlib

### DIFF
--- a/examples/plot_discrete.py
+++ b/examples/plot_discrete.py
@@ -21,10 +21,10 @@ df = df.set_index(df.Survived == 1).set_index(df.Pclass == 1, append=True)
 
 upset = UpSet(df, intersection_plot_elements=0)  # disable the default bar chart
 upset.add_stacked_bars(
-    by="Sex", colors=cm.Pastel1, title="Count by gender", elements=10
+    by="Sex", colors=cm.Pastel1, title="Count by sex", elements=10
 )
 upset.plot()
-plt.suptitle("Gender for first class and survival on Titanic")
+plt.suptitle("Sex for first class and survival on Titanic")
 plt.show()
 
 
@@ -32,7 +32,7 @@ upset = UpSet(
     df, show_counts=True, orientation="vertical", intersection_plot_elements=0
 )
 upset.add_stacked_bars(
-    by="Sex", colors=cm.Pastel1, title="Count by gender", elements=10
+    by="Sex", colors=cm.Pastel1, title="Count by sex", elements=10
 )
 upset.plot()
 plt.suptitle("Same, but vertical, with counts shown")

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -792,10 +792,10 @@ class UpSet:
                 }
             )
         )
-        styles["linewidth"].fillna(1, inplace=True)
-        styles["facecolor"].fillna(self._facecolor, inplace=True)
-        styles["edgecolor"].fillna(styles["facecolor"], inplace=True)
-        styles["linestyle"].fillna("solid", inplace=True)
+        styles["linewidth"] = styles["linewidth"].fillna(1)
+        styles["facecolor"] = styles["facecolor"].fillna(self._facecolor)
+        styles["edgecolor"] = styles["edgecolor"].fillna(styles["facecolor"])
+        styles["linestyle"] = styles["linestyle"].fillna("solid")
         del styles["hatch"]  # not supported in matrix (currently)
 
         x = np.repeat(np.arange(len(data)), n_cats)

--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -532,7 +532,7 @@ class UpSet:
         handles, labels = ax.get_legend_handles_labels()
         if self._horizontal:
             # Make legend order match visual stack order
-            ax.legend(reversed(handles), reversed(labels))
+            ax.legend(list(reversed(handles)), list(reversed(labels)))
         else:
             ax.legend()
 

--- a/upsetplot/tests/test_upsetplot.py
+++ b/upsetplot/tests/test_upsetplot.py
@@ -664,7 +664,7 @@ def test_add_stacked_bars_colors(colors, expected):
     ).cat.codes.map({0: "foo", 1: "bar", 2: "baz"})
 
     upset = UpSet(df)
-    upset.add_stacked_bars(by="label", colors=colors, title="Count by gender")
+    upset.add_stacked_bars(by="label", colors=colors, title="Count by sex")
     upset_axes = upset.plot()
     stacked_axes = upset_axes["extra1"]
     color_to_label = _get_color_to_label_from_legend(stacked_axes)


### PR DESCRIPTION
Currently, `upsetplot` does not work with the latest version of matplotlib, and has future warnings for functions that will be deprecated in the future. This was observed while running the code example in https://upsetplot.readthedocs.io/en/latest/auto_examples/plot_discrete.html (titanic example).

While I was at it, I also corrected the wording used in the example :).