### PR TITLE
changed labels to list to work with newer matplotlib

### DIFF
--- a/upsetplot/plotting.py
+++ b/upsetplot/plotting.py
@@ -532,7 +532,8 @@ class UpSet:
         handles, labels = ax.get_legend_handles_labels()
         if self._horizontal:
             # Make legend order match visual stack order
-            ax.legend(reversed(handles), reversed(labels))
+            ax.legend(list(reversed(handles)), list(reversed(labels)))
+
         else:
             ax.legend()
 
@@ -617,7 +618,7 @@ class UpSet:
         if value is None:
             if "_value" not in self._df.columns:
                 raise ValueError(
-                    "value cannot be set if data is a Series. " "Got %r" % value
+                    "value cannot be set if data is a Series. Got %r" % value
                 )
         else:
             if value not in self._df.columns:
@@ -992,7 +993,7 @@ class UpSet:
                 self._swapaxes(start_x, i - 0.4),
                 *self._swapaxes(end_x, 0.8),
                 facecolor=shading_style.get("facecolor", default_shading),
-                edgecolor=shading_style.get("edgecolor", None),
+                edgecolor=shading_style.get("edgecolor"),
                 ls=shading_style.get("linestyle", "-"),
                 lw=lw,
                 zorder=0,


### PR DESCRIPTION
In ``_plot_stacked_bars`` I always got an error with the iterator format of handles and labels. It seems that this is due to a change in how Matplotlib works with them. I changed the legend setting to ``ax.legend(list(reversed(handles)), list(reversed(labels)))`` which now works for me without an error.